### PR TITLE
Make log level persisting optional

### DIFF
--- a/lib/loglevel.js
+++ b/lib/loglevel.js
@@ -118,12 +118,14 @@
                enableLoggingWhenConsoleArrives(methodName, level);
     };
 
-    self.setLevel = function (level) {
+    self.setLevel = function (level, persist) {
         if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
             level = self.levels[level.toUpperCase()];
         }
         if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
-            persistLevelIfPossible(level);
+            if (persist !== false) {  // defaults to true
+                persistLevelIfPossible(level);
+            }
             replaceLoggingMethods(level);
             if (typeof console === undefinedType && level < self.levels.SILENT) {
                 return "No console available for logging";
@@ -133,12 +135,12 @@
         }
     };
 
-    self.enableAll = function() {
-        self.setLevel(self.levels.TRACE);
+    self.enableAll = function(persist) {
+        self.setLevel(self.levels.TRACE, persist);
     };
 
-    self.disableAll = function() {
-        self.setLevel(self.levels.SILENT);
+    self.disableAll = function(persist) {
+        self.setLevel(self.levels.SILENT, persist);
     };
 
     // Grab the current global log variable in case of overwrite


### PR DESCRIPTION
We want to set a higher log level in production by default but don't want it to be saved on users' browsers. Making persistence optional seemed like a good way to achieve this. The patch keeps the old behavior (persist by default) for backwards compatibility.